### PR TITLE
Hides nav bars that shouldn't be visible

### DIFF
--- a/css/components/nav.scss
+++ b/css/components/nav.scss
@@ -34,8 +34,7 @@ $Nav-item-color-hover: $Theme-color-yellowOrange;
 }
 
 .Nav.is-hidden {
-  opacity: 0;
-  pointer-events: none;
+  display: none;
 }
 
 //

--- a/css/legacy/blue-components/blue/components/_nav_overlay.scss
+++ b/css/legacy/blue-components/blue/components/_nav_overlay.scss
@@ -42,7 +42,7 @@ $NavOverlay-item-color-hover: $Theme-color-yellowOrange;
   height: calc(100% - #{$Theme-nav-height-mobile} + 200px);
   padding: $Theme-spacing-default 0;
 
-  opacity: 0;
+  display: none;
 
   transition: all 0.2s ease-in-out;
 }
@@ -102,5 +102,5 @@ $NavOverlay-item-color-hover: $Theme-color-yellowOrange;
 
   background-color: $Theme-color-white;
 
-  opacity: 1;
+  display: block;
 }


### PR DESCRIPTION
When pressing the tab key, it was selecting non-visible bars, because although they weren't visible they were selectable. Animations are working as before.