### PR TITLE
Hide Footer-work on tablet and mobile devices.

### DIFF
--- a/css/legacy/blue-components/blue/components/_footer.scss
+++ b/css/legacy/blue-components/blue/components/_footer.scss
@@ -82,7 +82,7 @@
   color: $Theme-color-limedSpruce;
 }
 
-@include media('>=tablet') {
+@include media('>=desktop') {
   .Footer-credits {
     flex-basis: 70%;
     align-items: flex-start;


### PR DESCRIPTION
On the tablet devices, engagement button text is to big for the work area. Hide footer work area at mobile and tablet devices.